### PR TITLE
Fix windows build

### DIFF
--- a/packages/vaul/package.json
+++ b/packages/vaul/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "type-check": "tsc --noEmit",
     "build": "pnpm type-check && bunchee && pnpm copy-assets",
-    "copy-assets": "cp -r ./src/style.css ./style.css",
+    "copy-assets": "ncp ./src/style.css ./style.css",
     "dev": "bunchee --watch",
     "lint": "eslint src/"
   },
@@ -49,6 +49,7 @@
     "@types/react-dom": "catalog:",
     "bunchee": "^5.1.5",
     "eslint": "^7.32.0",
+    "ncp": "^2.0.0",
     "prettier": "^2.5.1",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/eslint-config: {}
+
   packages/test-app:
     dependencies:
       clsx:
@@ -112,6 +114,9 @@ importers:
       eslint:
         specifier: ^7.32.0
         version: 7.32.0
+      ncp:
+        specifier: ^2.0.0
+        version: 2.0.0
       prettier:
         specifier: ^2.5.1
         version: 2.8.8
@@ -2019,6 +2024,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  ncp@2.0.0:
+    resolution: {integrity: sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==}
+    hasBin: true
 
   next@16.1.0:
     resolution: {integrity: sha512-Y+KbmDbefYtHDDQKLNrmzE/YYzG2msqo2VXhzh5yrJ54tx/6TmGdkR5+kP9ma7i7LwZpZMfoY3m/AoPPPKxtVw==}
@@ -4677,6 +4686,8 @@ snapshots:
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
+
+  ncp@2.0.0: {}
 
   next@16.1.0(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:


### PR DESCRIPTION
Native windows development is kinda required (not WSL) because of reliance on playwright tests. Build was broken on windows due to use of `cp`, replaced it for the `ncp` node package that is x-platform.